### PR TITLE
feat: improve local availability message

### DIFF
--- a/apps/web/components/availability-message.module.css
+++ b/apps/web/components/availability-message.module.css
@@ -1,0 +1,48 @@
+.message {
+  display: inline;
+}
+
+.clock {
+  --hour-angle: 0deg;
+  --minute-angle: 0deg;
+  position: relative;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.375em;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  vertical-align: -0.12em;
+}
+
+.clock::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  content: "";
+  transform: translate(-50%, -50%);
+}
+
+.hourHand,
+.minuteHand {
+  position: absolute;
+  bottom: 50%;
+  left: 50%;
+  width: 1px;
+  background: currentColor;
+  transform-origin: 50% 100%;
+}
+
+.hourHand {
+  height: 27%;
+  transform: translateX(-50%) rotate(var(--hour-angle));
+}
+
+.minuteHand {
+  height: 38%;
+  transform: translateX(-50%) rotate(var(--minute-angle));
+}

--- a/apps/web/components/availability-message.tsx
+++ b/apps/web/components/availability-message.tsx
@@ -2,21 +2,104 @@
 
 import * as React from "react";
 
-const TBILISI_TIME_ZONE = "Asia/Tbilisi";
+import styles from "./availability-message.module.css";
 
-const timeFormatter = new Intl.DateTimeFormat("en-GB", {
+const TBILISI_TIME_ZONE = "Asia/Tbilisi";
+const WORKDAY_START_HOUR = 11;
+const WORKDAY_END_HOUR = 20;
+
+const partsFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: TBILISI_TIME_ZONE,
-  hour: "2-digit",
-  minute: "2-digit",
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
   hourCycle: "h23",
 });
 
-function getTbilisiHour(date: Date) {
-  const hour = timeFormatter
-    .formatToParts(date)
-    .find((part) => part.type === "hour")?.value;
+interface TimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
 
-  return Number(hour);
+function getTbilisiTime(date: Date): TimeParts {
+  const parts = Object.fromEntries(
+    partsFormatter
+      .formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, Number(part.value)]),
+  );
+
+  return parts as unknown as TimeParts;
+}
+
+function getTbilisiOffsetMinutes(date: Date, parts: TimeParts) {
+  const tbilisiAsUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+
+  return Math.round((tbilisiAsUtc - date.getTime()) / 60_000);
+}
+
+function formatOffset(hours: number) {
+  const absoluteHours = Math.abs(hours);
+  const numberWords = [
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "ten",
+    "eleven",
+    "twelve",
+    "thirteen",
+    "fourteen",
+  ];
+  const value = Number.isInteger(absoluteHours)
+    ? (numberWords[absoluteHours] ?? String(absoluteHours))
+    : absoluteHours.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+  const unit = absoluteHours === 1 ? "hour" : "hours";
+  const direction = hours > 0 ? "ahead of" : "behind";
+
+  return `${value} ${unit} ${direction} you`;
+}
+
+function formatHour(hour: number) {
+  return `${hour % 12 || 12} ${hour < 12 ? "am" : "pm"}`;
+}
+
+function Clock({ hour, minute }: { hour: number; minute: number }) {
+  return (
+    <span
+      className={styles.clock}
+      style={
+        {
+          "--hour-angle": `${(hour % 12) * 30 + minute * 0.5}deg`,
+          "--minute-angle": `${minute * 6}deg`,
+        } as React.CSSProperties
+      }
+      aria-hidden="true"
+    >
+      <span className={styles.hourHand} />
+      <span className={styles.minuteHand} />
+    </span>
+  );
 }
 
 export function AvailabilityMessage() {
@@ -33,15 +116,32 @@ export function AvailabilityMessage() {
 
   if (!now) return <>I&apos;ll return to you in an hour.</>;
 
-  const hour = getTbilisiHour(now);
-  const isSleeping = hour >= 20 || hour < 11;
+  const tbilisi = getTbilisiTime(now);
+  const isWorking =
+    tbilisi.hour >= WORKDAY_START_HOUR && tbilisi.hour < WORKDAY_END_HOUR;
 
-  if (!isSleeping) return <>I&apos;ll return to you in an hour.</>;
+  const visitorOffsetMinutes = -now.getTimezoneOffset();
+  const offsetHours =
+    (getTbilisiOffsetMinutes(now, tbilisi) - visitorOffsetMinutes) / 60;
 
-  return (
+  const message = (
     <>
-      Currently I&apos;m in bed ({timeFormatter.format(now)}), will answer you
-      first thing tomorrow.
+      <Clock hour={tbilisi.hour} minute={tbilisi.minute} />It&apos;s{" "}
+      {formatHour(tbilisi.hour)} here
+      {offsetHours === 0 ? (
+        <>, and we&apos;re in the same time zone. </>
+      ) : (
+        <>, so I&apos;m {formatOffset(offsetHours)}. </>
+      )}
+      {isWorking ? (
+        <>I&apos;ll reply in about an hour.</>
+      ) : (
+        <>
+          I&apos;m probably already in bed, but I&apos;ll reply first thing tomorrow.
+        </>
+      )}
     </>
   );
+
+  return <span className={styles.message}>{message}</span>;
 }


### PR DESCRIPTION
## Summary
- show Fedor’s current Tbilisi hour without minutes
- compare Tbilisi with the visitor’s timezone
- draw an inline analog clock
- tailor reply expectations to working and sleeping hours

## Validation
- `biome lint apps/web`
- `pnpm --filter web exec tsc --noEmit`